### PR TITLE
Change figure dumping logic

### DIFF
--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -36,6 +36,14 @@ const room = Room.create(shroom, {
    `,
 });
 
+const avatar = new Avatar({
+  look: "hd-180-1.hr-100-61.ch-210-66.lg-280-110.sh-305-62",
+  direction: 4,
+  roomX: 0,
+  roomY: 0,
+  roomZ: 0,
+});
+
 room.x = 100;
 room.y = 200;
 
@@ -43,5 +51,7 @@ room.wallTexture = loadRoomTexture("./images/tile.png");
 room.floorTexture = loadRoomTexture("./images/tile.png");
 room.wallColor = "#dbbe6e";
 room.floorColor = "#eeeeee";
+
+room.addRoomObject(avatar);
 
 application.stage.addChild(room);

--- a/src/downloading/dumpFigureLibraries.ts
+++ b/src/downloading/dumpFigureLibraries.ts
@@ -25,7 +25,9 @@ export async function dumpFigureLibraries(
       const fileName = `${id}.swf`;
       const file = `${gordon}/${fileName}`;
 
-      const resolvedOutPath = path.resolve(out);
+      const resolvedOutPath = path.resolve(path.join(out, id));
+      await fs.mkdir(resolvedOutPath, { recursive: true });
+
       const swfLocation = path.join(resolvedOutPath, fileName);
 
       const success = () =>

--- a/src/downloading/state.ts
+++ b/src/downloading/state.ts
@@ -139,7 +139,7 @@ export async function run({
       figureMapString,
       async (name) => {
         const file = await fs.readFile(
-          path.join(figureFolder, `${name}_manifest.bin`)
+          path.join(figureFolder, `${name}/${name}_manifest.bin`)
         );
 
         return file.toString("utf-8");

--- a/src/objects/avatar/AvatarLoader.ts
+++ b/src/objects/avatar/AvatarLoader.ts
@@ -1,13 +1,6 @@
 import { createLookServer, loadOffsetMapFromJson, LookServer } from "./util";
-import { avatarFrames, avatarFramesObject } from "./util/avatarFrames";
+import { avatarFramesObject } from "./util/avatarFrames";
 import { LookOptions } from "./util/createLookServer";
-import {
-  getAvatarDrawDefinition,
-  Dependencies,
-  AvatarDrawDefinition,
-} from "./util/getAvatarDrawDefinition";
-import { parseLookString } from "./util/parseLookString";
-import * as PIXI from "pixi.js";
 import {
   AvatarLoaderResult,
   IAvatarLoader,
@@ -15,7 +8,7 @@ import {
 import { HitTexture } from "../hitdetection/HitTexture";
 
 interface Options {
-  resolveImage: (id: string) => Promise<HitTexture>;
+  resolveImage: (id: string, library: string) => Promise<HitTexture>;
   createLookServer: () => Promise<LookServer>;
 }
 
@@ -46,14 +39,13 @@ export class AvatarLoader implements IAvatarLoader {
             ).getOffset,
         });
       },
-      resolveImage: async (id) => {
-        return HitTexture.fromUrl(`${resourcePath}/figure/${id}.png`);
+      resolveImage: async (id, type) => {
+        return HitTexture.fromUrl(`${resourcePath}/figure/${type}/${id}.png`);
       },
     });
   }
 
   async getAvatarDrawDefinition(look: string): Promise<AvatarLoaderResult> {
-    const parsedLook = parseLookString(look);
     const loadedFiles = new Map<string, Promise<HitTexture>>();
 
     const getDrawDefinition = await this.lookServer;
@@ -66,7 +58,7 @@ export class AvatarLoader implements IAvatarLoader {
         if (globalFile != null) {
           loadedFiles.set(item.fileId, globalFile);
         } else {
-          const file = this.options.resolveImage(item.fileId);
+          const file = this.options.resolveImage(item.fileId, item.library);
           this.globalCache.set(item.fileId, file);
           loadedFiles.set(item.fileId, file);
         }

--- a/src/objects/avatar/AvatarLoader.ts
+++ b/src/objects/avatar/AvatarLoader.ts
@@ -39,8 +39,10 @@ export class AvatarLoader implements IAvatarLoader {
             ).getOffset,
         });
       },
-      resolveImage: async (id, type) => {
-        return HitTexture.fromUrl(`${resourcePath}/figure/${type}/${id}.png`);
+      resolveImage: async (id, library) => {
+        return HitTexture.fromUrl(
+          `${resourcePath}/figure/${library}/${id}.png`
+        );
       },
     });
   }

--- a/src/objects/avatar/util/createLookServer.ts
+++ b/src/objects/avatar/util/createLookServer.ts
@@ -37,7 +37,7 @@ export async function createLookServer({
   const { getSetType } = parseFigureData(figureDataXml);
   const figureMap = parseFigureMap(figureMapXml);
 
-  const getOffset = await loadOffsetMap(figureMap);
+  const getOffset = await loadOffsetMap(figureMap.libraries);
 
   return ({ look, action, actions, direction }: LookOptions) =>
     getAvatarDrawDefinition(
@@ -47,6 +47,6 @@ export async function createLookServer({
         actions: actions,
         direction,
       },
-      { getOffset, getSetType }
+      { getOffset, getSetType, getLibraryOfPart: figureMap.getLibraryOfPart }
     );
 }

--- a/src/objects/avatar/util/createOffsetSnapshot.ts
+++ b/src/objects/avatar/util/createOffsetSnapshot.ts
@@ -10,7 +10,7 @@ export async function createOffsetSnapshot(
   const figureMapXml = await parseStringAsync(figureMapStr);
   const figureMap = parseFigureMap(figureMapXml);
 
-  const { offsetMap } = await loadOffsetMap(figureMap, getManifest);
+  const { offsetMap } = await loadOffsetMap(figureMap.libraries, getManifest);
 
   const obj: any = {};
 

--- a/src/objects/avatar/util/getAvatarDrawDefinition.ts
+++ b/src/objects/avatar/util/getAvatarDrawDefinition.ts
@@ -11,6 +11,7 @@ import { getDrawOrder } from "./drawOrder";
 
 export type AvatarDrawPart = {
   fileId: string;
+  library: string;
   x: number;
   y: number;
   color: string | undefined;
@@ -27,6 +28,7 @@ export interface AvatarDrawDefinition {
 export interface Dependencies {
   getSetType: GetSetType;
   getOffset: GetOffset;
+  getLibraryOfPart: (id: string, type: string) => string | undefined;
 }
 
 export type PrimaryAction =
@@ -58,7 +60,7 @@ interface Options {
  */
 export function getAvatarDrawDefinition(
   { parsedLook, action, actions, direction }: Options,
-  { getOffset, getSetType }: Dependencies
+  { getOffset, getSetType, getLibraryOfPart }: Dependencies
 ): AvatarDrawDefinition | undefined {
   const parts = Array.from(parsedLook.entries()).flatMap(
     ([type, { setId, colorId }]) => {
@@ -171,8 +173,14 @@ export function getAvatarDrawDefinition(
           const offset = getOffset(id);
           if (offset == null) return;
 
+          const library = getLibraryOfPart(p.id, p.type);
+          if (library == null) {
+            throw new Error(`Invalid library ${id} ${p.type}`);
+          }
+
           return {
             fileId: id,
+            library: library,
             x: -offset.offsetX,
             y: -offset.offsetY,
             color: `#${p.color}`,

--- a/src/objects/avatar/util/parseFigureMap.ts
+++ b/src/objects/avatar/util/parseFigureMap.ts
@@ -1,7 +1,27 @@
 export function parseFigureMap(figureMapXml: any) {
   const libs: any[] = figureMapXml.map.lib;
 
-  return libs.map((lib: any) => {
-    return lib["$"].id as string;
+  const partToLibrary = new Map<string, string>();
+  const libraries: string[] = [];
+
+  libs.forEach((lib: any) => {
+    const parts: any[] = lib.part;
+
+    parts.forEach((part) => {
+      const uniqueId = getUniqueId(part["$"].id, part["$"].type);
+      partToLibrary.set(uniqueId, lib["$"].id);
+    });
+
+    libraries.push(lib["$"].id);
   });
+
+  return {
+    getLibraryOfPart: (id: string, type: string) =>
+      partToLibrary.get(getUniqueId(id, type)),
+    libraries,
+  };
 }
+
+const getUniqueId = (id: string, type: string) => {
+  return `${id}_${type}`;
+};


### PR DESCRIPTION
This PR changes the logic of the figure asset dumping process.
The contents of the `.swf` will now get dumped into a folder named after the library name.

This reduces the amount of files in a single folder and makes the experience of navigating the figure folder better.