### PR TITLE
Fixed bug where "shroom dump" crashes randomly

### DIFF
--- a/src/downloading/extractSwf.ts
+++ b/src/downloading/extractSwf.ts
@@ -1,9 +1,9 @@
-import { exec } from "child_process";
+import { exec, ExecException } from "child_process";
 import * as path from "path";
 
 function execute(command: string) {
   return new Promise((resolve, reject) =>
-    exec(command, (error, stdout, stderr) =>
+    exec(command, {maxBuffer: 1024 * 1024}, (error: ExecException | null, stdout: string, stderr: string) =>
       error ? reject(error) : resolve(stdout)
     )
   );


### PR DESCRIPTION
While I fixed my problems on Linux, I believe to have found the reason for the random crashes of `shroom dump`. It seems like the buffer is too small for the output of `swfdump` when using `child_process.exec` on some operating systems. For example, the buffer limit is only 200 KB on my machine, the output of hh_human_item.swf for example is about 290 KB. This pull request manually increases the buffer to `1024 * 1024`, like it should be on all operating systems according to https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback.