### PR TITLE
add alpha value to furniture

### DIFF
--- a/src/objects/furniture/BaseFurniture.tsx
+++ b/src/objects/furniture/BaseFurniture.tsx
@@ -46,6 +46,7 @@ export class BaseFurniture
   private _refreshZIndex: boolean = false;
 
   private _highlight: boolean = false;
+  private _alpha: number = 1;
 
   public get highlight() {
     return this._highlight;
@@ -54,6 +55,15 @@ export class BaseFurniture
   public set highlight(value) {
     this._highlight = value;
     this._refreshFurniture = true;
+  }
+
+  public get alpha() {
+    return this._alpha;
+  }
+
+  public set alpha(value) {
+    this._alpha = value;
+    this._updateFurniture();
   }
 
   public get onClick() {
@@ -371,8 +381,10 @@ export class BaseFurniture
         sprite.visible = false;
       } else {
         sprite.visible = true;
-        sprite.alpha = 0.195;
+        sprite.alpha = this.alpha / 5;
       }
+    } else {
+      sprite.alpha = this.alpha;
     }
 
     if (mask) {

--- a/src/objects/furniture/BaseFurniture.tsx
+++ b/src/objects/furniture/BaseFurniture.tsx
@@ -63,7 +63,7 @@ export class BaseFurniture
 
   public set alpha(value) {
     this._alpha = value;
-    this._updateFurniture();
+    this._refreshFurniture = true;
   }
 
   public get onClick() {

--- a/src/objects/furniture/FloorFurniture.tsx
+++ b/src/objects/furniture/FloorFurniture.tsx
@@ -46,6 +46,14 @@ export class FloorFurniture
     this._updateHighlight();
   }
 
+  public get alpha() {
+    return this._baseFurniture.alpha;
+  }
+
+  public set alpha(value: number) {
+    this._baseFurniture.alpha = value;
+  }
+
   public get type() {
     return this._type;
   }

--- a/src/objects/furniture/WallFurniture.tsx
+++ b/src/objects/furniture/WallFurniture.tsx
@@ -66,6 +66,14 @@ export class WallFurniture extends RoomObject implements IFurniture {
     this._highlight = this._highlight;
   }
 
+  public get alpha() {
+    return this._baseFurniture.alpha;
+  }
+
+  public set alpha(value: number) {
+    this._baseFurniture.alpha = value;
+  }
+
   public get type() {
     return this._type;
   }


### PR DESCRIPTION
I could not find a way to change the alpha values of a single furniture. This functionality is needed e.g. when dragging a furniture around in the room whilst moving it.

This commit adds a new property alpha to BaseFurniture which calls updateFurniture when changed. createSprite now sets the PIXI.Sprite's alpha value to that of the BaseFurniture.

This commit changes the default alpha of furniture shadows from 0.195 to 0.2. Not sure if this is a big deal or not.

Example use:
```typescript
let furni = new FloorFurniture({
  roomX: 2,
  roomY: 1,
  roomZ: 0,
  direction: 0,
  type: "plant_pineapple",
  animation: "0",
});

furni.alpha = 0.5;
```