### PR TITLE
Add ability to use multiple `PIXI.Application`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `BaseAvatar` for rendering avatars without a room
 - Add `BaseFurniture` for rendering furniture without a room
 - Add `onActiveTileChange` events for detecing hovered tile
+- Add ability to share a shroom instance with multiple applications through `Shroom.createShared`
 
 ### Fixed
 

--- a/src/objects/Shroom.ts
+++ b/src/objects/Shroom.ts
@@ -6,15 +6,27 @@ import { FurnitureData } from "./furniture/FurnitureData";
 import { HitDetection } from "./hitdetection/HitDetection";
 import { Dependencies } from "./room/Room";
 
-const defaultConfig: IConfiguration = {};
-let globalDependencies: Dependencies | undefined;
-
 export class Shroom {
   constructor(public readonly dependencies: Dependencies) {}
 
-  static create({
+  /**
+   * Create a shroom instance
+   */
+  static create(
+    options: {
+      resourcePath?: string;
+      application: PIXI.Application;
+    } & Partial<Dependencies>
+  ) {
+    return this.createShared(options).for(options.application);
+  }
+
+  /**
+   * Create a shared shroom instance. This is useful if you have multiple
+   * `PIXI.Application` which all share the same shroom dependencies.
+   */
+  static createShared({
     resourcePath,
-    application,
     configuration,
     animationTicker,
     avatarLoader,
@@ -23,21 +35,31 @@ export class Shroom {
     hitDetection,
   }: {
     resourcePath?: string;
-    application: PIXI.Application;
   } & Partial<Dependencies>) {
-    furnitureData = furnitureData ?? FurnitureData.create(resourcePath);
+    const _furnitureData = furnitureData ?? FurnitureData.create(resourcePath);
+    const _avatarLoader = avatarLoader ?? AvatarLoader.create(resourcePath);
+    const _furnitureLoader =
+      furnitureLoader ?? FurnitureLoader.create(_furnitureData, resourcePath);
+    const _configuration = configuration ?? {};
 
-    const realDependencies: Dependencies = {
-      animationTicker: animationTicker ?? AnimationTicker.create(application),
-      avatarLoader: avatarLoader ?? AvatarLoader.create(resourcePath),
-      furnitureLoader:
-        furnitureLoader ?? FurnitureLoader.create(furnitureData, resourcePath),
-      hitDetection: hitDetection ?? HitDetection.create(application),
-      configuration: configuration ?? {},
-      furnitureData,
-      application,
+    return {
+      for: (application: PIXI.Application) => {
+        const _hitDetection = hitDetection ?? HitDetection.create(application);
+        const _animationTicker =
+          animationTicker ?? AnimationTicker.create(application);
+
+        const realDependencies: Dependencies = {
+          animationTicker: _animationTicker,
+          avatarLoader: _avatarLoader,
+          furnitureLoader: _furnitureLoader,
+          hitDetection: _hitDetection,
+          configuration: _configuration,
+          furnitureData: _furnitureData,
+          application,
+        };
+
+        return new Shroom(realDependencies);
+      },
     };
-
-    return new Shroom(realDependencies);
   }
 }


### PR DESCRIPTION
This PR adds the ability to create a shared shroom instance.
The way to do it is by using:

```ts
const shroom = Shroom.createShared({ resourcePath: "." });
const shroom1 = shroom.for(application1);
const shroom2 = shroom.for(application2);
```

Closes #55 