### PR TITLE
Skip cache for BaseAvatar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules
 /storybook/public/resources
 /storybook/public/images
 yarn.lock
+/.idea

--- a/src/objects/avatar/BaseAvatar.ts
+++ b/src/objects/avatar/BaseAvatar.ts
@@ -33,6 +33,7 @@ export interface BaseAvatarOptions {
   position: { x: number; y: number };
   zIndex: number;
   skipBodyParts?: boolean;
+  skipCaching?: boolean;
   headOnly?: boolean;
   onLoad?: () => void;
 }
@@ -53,6 +54,7 @@ export class BaseAvatar extends PIXI.Container {
 
   private _skipBodyParts: boolean;
   private _headOnly: boolean;
+  private _skipCaching: boolean;
 
   private _currentFrame: number = 0;
   private _clickHandler: ClickHandler = new ClickHandler();
@@ -153,6 +155,7 @@ export class BaseAvatar extends PIXI.Container {
     this._onLoad = options.onLoad;
     this._skipBodyParts = options.skipBodyParts ?? false;
     this._headOnly = options.headOnly ?? false;
+    this._skipCaching = options.skipCaching ?? false;
   }
 
   private _updateSpritesZIndex() {
@@ -298,7 +301,7 @@ export class BaseAvatar extends PIXI.Container {
       const requestId = ++this._updateId;
 
       this.dependencies.avatarLoader
-        .getAvatarDrawDefinition({ ...lookOptions, initial: true })
+        .getAvatarDrawDefinition({ ...lookOptions, initial: true, skipCaching: this._skipCaching })
         .then((result) => {
           if (requestId !== this._updateId) return;
 

--- a/src/objects/avatar/util/createLookServer.ts
+++ b/src/objects/avatar/util/createLookServer.ts
@@ -16,6 +16,7 @@ export interface LookOptions {
   item?: string | number;
   effect?: { type: "dance" | "fx"; id: string };
   initial?: boolean;
+  skipCaching?: boolean;
 }
 
 export interface LookServer {

--- a/storybook/stories/Avatar.stories.ts
+++ b/storybook/stories/Avatar.stories.ts
@@ -374,16 +374,6 @@ export function headRotation() {
                       
 export function BaseAvatarClothes() {
   return createShroom(({ application, shroom }) => {
-    // const room = Room.create(shroom, {
-    //   tilemap: `
-    //        xxxxxxxx
-    //        x0000000
-    //        x0000000
-    //        x0000000
-    //        x0000000
-    //       `,
-    // });
-
     const baseAvatar = BaseAvatar.fromShroom(shroom, {
       look: {
         look: 'ch-210-66',
@@ -392,6 +382,7 @@ export function BaseAvatarClothes() {
       },
       zIndex: 1,
       skipBodyParts: true,
+      skipCaching: true,
       position: {
         x: 0,
         y: 32
@@ -409,6 +400,7 @@ export function BaseAvatarClothes() {
       },
       zIndex: 1,
       headOnly: true,
+      skipCaching: true,
       position: {
         x: 100,
         y: 200


### PR DESCRIPTION
I think most of the time, BaseAvatar is going to be used only in one direction/head rotation combo. This makes the other 63 combinations unused and therefore there is no point in caching these. This is a flag to say not to cache those 63 combinations, only the 1 that is used. It's optional and defaults to false (normal behaviour).