### PR TITLE
Secure WebSocket on Proxy 

### DIFF
--- a/src/cli/index.tsx
+++ b/src/cli/index.tsx
@@ -67,6 +67,14 @@ yargs(hideBin(process.argv))
           default: false,
           describe: "Sends the length integer as a prefix to the message",
         })
+        .option("key", {
+          type: "string",
+          describe: "Path to key for secure websocket"
+        })
+        .option("cert", {
+          type: "string",
+          describe: "Certificate for secure websocket"
+        })
         .option("debug", {
           type: "boolean",
           describe: "Run in debug mode",
@@ -84,6 +92,8 @@ yargs(hideBin(process.argv))
       port: number;
       prependLengthPrefix: boolean;
       debug: boolean;
+      cert?: string;
+      key?: string;
       targetHost?: string;
     }) => {
       runForwardingServer({
@@ -92,6 +102,8 @@ yargs(hideBin(process.argv))
         debug: options.debug,
         prependLengthPrefix: options.prependLengthPrefix,
         targetHost: options.targetHost,
+        keyPath: options.key,
+        certPath: options.cert,
       });
     }
   )


### PR DESCRIPTION
Specify --cert and --key for certificate and private key paths and wss server will be started instead.

There is currently no error handling for not specifiying correct paths to cert and private key, however this seems to follow for the rest of the socket creation. Not sure if it is required.

Note: further testing may be required as I currently cannot test properly (although same behaviour is observed on wss and ws).